### PR TITLE
Fix:  Network icon logic for wired/wireless networks

### DIFF
--- a/widgets/bar/QSPanelButton.tsx
+++ b/widgets/bar/QSPanelButton.tsx
@@ -10,8 +10,8 @@ import AstalBluetooth from "gi://AstalBluetooth";
 
 function NetworkIcon() {
   const network = AstalNetwork.get_default();
-  if (!network.wifi)
-    return <image iconName={bind(network.wired, "iconName")} />;
+  if (!network.wired)
+    return <image iconName={bind(network.wifi, "iconName")} />;
 
   const icon = Variable.derive(
     [


### PR DESCRIPTION
This changes the icon logic for wired/wireless networks so that it checks if you have a wired connection and if it dosent it shows the wifi icon.

I believe it fixes the issue this person was having: https://www.reddit.com/r/unixporn/comments/1htkoz1/comment/mabm9su/