### PR TITLE
Feature: Add bluetooth page

### DIFF
--- a/styles/widgets/quicksettings.scss
+++ b/styles/widgets/quicksettings.scss
@@ -3,6 +3,7 @@
 
 .qs-container {
   min-width: 300px;
+
   button {
     outline-color: $fg;
   }
@@ -11,13 +12,14 @@
     border-radius: $window-border-radius;
     background-color: color.adjust($fg, $alpha: -0.9);
 
-    > * {
+    >* {
       padding: 0 4px;
 
       &:first-child {
         padding: $window-padding;
       }
     }
+
     &.active {
       background-color: $accent;
       color: $bg;
@@ -27,6 +29,7 @@
   flowbox flowboxchild {
     padding: 0;
     outline-color: $fg;
+
     &:selected {
       background-color: transparent;
     }
@@ -42,17 +45,21 @@
     label {
       font-size: 1.2rem;
     }
+
     button {
       padding: 0.3rem 0.5rem;
       border-radius: $window-border-radius;
       background-color: color.adjust($fg, $alpha: -0.9);
+
       label {
         font-size: 0.95rem;
       }
+
       &:hover {
         background-color: color.adjust($fg, $alpha: -0.65);
       }
     }
+
     .powermenu {
       &:hover {
         color: $red;
@@ -67,6 +74,7 @@
       border-radius: $window-border-radius;
       background-color: color.adjust($fg, $alpha: -0.9);
     }
+
     // margin-bottom: 0.7rem;
   }
 
@@ -79,6 +87,7 @@
       padding: 1rem 0;
       background-color: transparent;
       outline-color: $fg;
+
       &:checked {
         color: $bg;
         border-radius: $window-border-radius;
@@ -88,11 +97,14 @@
 
     popover contents {
       border-radius: $window-border-radius;
+
       modelbutton {
         background-color: color.adjust($fg, $alpha: -0.9);
+
         &:first-child {
           margin-bottom: 0.3rem;
         }
+
         &:hover {
           background-color: color.adjust($fg, $alpha: -0.65);
         }
@@ -102,7 +114,8 @@
     &:hover {
       background-color: color.adjust($fg, $alpha: -0.65);
     }
-    > * {
+
+    >* {
       padding: 0.5rem;
     }
 
@@ -118,6 +131,7 @@
 
   .qs-page {
     margin: $window-padding;
+
     .button {
       padding: 0.4rem 0.8rem;
       background-color: color.adjust($fg, $alpha: -0.9);
@@ -128,7 +142,7 @@
       }
 
       &:active {
-        > * {
+        >* {
           transform: none;
         }
 
@@ -148,8 +162,9 @@
     }
   }
 
-  .wifi-page {
+  .wifi-page .bluetooth-page {
     margin: 0;
+
     .header {
       margin: $window-padding;
       margin-bottom: 0;

--- a/widgets/quicksettings/QSWindow.tsx
+++ b/widgets/quicksettings/QSWindow.tsx
@@ -179,6 +179,12 @@ function BluetoothArrowButton() {
     },
   );
 
+  const startBluetoothDiscovery = () => {
+    if (btAdapter.powered && !btAdapter.discovering) {
+      btAdapter.start_discovery();
+    }
+  };
+
   return (
     <ArrowButton
       icon={bind(btAdapter, "powered").as(
@@ -188,6 +194,7 @@ function BluetoothArrowButton() {
       subtitle={deviceConnected()}
       onClicked={() => bluetooth.toggle()}
       onArrowClicked={() => {
+        startBluetoothDiscovery();  // Start Bluetooth discovery when arrow is clicked
         qsPage.set("bluetooth");
       }}
       connection={[btAdapter, "powered"]}

--- a/widgets/quicksettings/QSWindow.tsx
+++ b/widgets/quicksettings/QSWindow.tsx
@@ -188,7 +188,6 @@ function BluetoothArrowButton() {
       subtitle={deviceConnected()}
       onClicked={() => bluetooth.toggle()}
       onArrowClicked={() => {
-        btAdapter.start_discovery();
         qsPage.set("bluetooth");
       }}
       connection={[btAdapter, "powered"]}

--- a/widgets/quicksettings/QSWindow.tsx
+++ b/widgets/quicksettings/QSWindow.tsx
@@ -19,6 +19,7 @@ import AstalBluetooth from "gi://AstalBluetooth";
 import BatteryPage from "./pages/BatteryPage";
 import SpeakerPage from "./pages/SpeakerPage";
 import WifiPage from "./pages/WifiPage";
+import BluetoothPage from "./pages/BluetoothPage";
 
 export const WINDOW_NAME = "quicksettings";
 export const qsPage = Variable("main");
@@ -165,7 +166,7 @@ function WifiArrowButton() {
   );
 }
 
-function WifiBluetooth() {
+function BluetoothArrowButton() {
   const bluetooth = AstalBluetooth.get_default();
   const btAdapter = bluetooth.adapter;
   const deviceConnected = Variable.derive(
@@ -177,6 +178,26 @@ function WifiBluetooth() {
       return "No device";
     },
   );
+
+  return (
+    <ArrowButton
+      icon={bind(btAdapter, "powered").as(
+        (p) => `bluetooth-${p ? "" : "disabled-"}symbolic`,
+      )}
+      title="Bluetooth"
+      subtitle={deviceConnected()}
+      onClicked={() => bluetooth.toggle()}
+      onArrowClicked={() => {
+        btAdapter.start_discovery();
+        qsPage.set("bluetooth");
+      }}
+      connection={[btAdapter, "powered"]}
+    />
+  );
+}
+
+function WifiBluetooth() {
+  const bluetooth = AstalBluetooth.get_default();
   const wifi = AstalNetwork.get_default().wifi;
 
   return (
@@ -188,16 +209,7 @@ function WifiBluetooth() {
       }}
     >
       {!!wifi && <WifiArrowButton />}
-      <ArrowButton
-        icon={bind(btAdapter, "powered").as(
-          (p) => `bluetooth-${p ? "" : "disabled-"}symbolic`,
-        )}
-        title="Bluetooth"
-        subtitle={deviceConnected()}
-        onClicked={() => bluetooth.toggle()}
-        onArrowClicked={() => console.log("Will add bt page later")}
-        connection={[btAdapter, "powered"]}
-      />
+      {!!bluetooth && <BluetoothArrowButton />}
     </box>
   );
 }
@@ -237,6 +249,7 @@ function QSWindow(_gdkmonitor: Gdk.Monitor) {
           <BatteryPage />
           <SpeakerPage />
           <WifiPage />
+          <BluetoothPage />
         </stack>
       </box>
     </PopupWindow>

--- a/widgets/quicksettings/pages/BluetoothPage.tsx
+++ b/widgets/quicksettings/pages/BluetoothPage.tsx
@@ -7,6 +7,7 @@ import { bash } from "../../../utils";
 export default function BluetoothPage() {
   const bluetooth = AstalBluetooth.get_default();
   const btAdapter = bluetooth.adapter;
+  btAdapter.start_discovery();
 
   return (
     <box
@@ -45,6 +46,7 @@ export default function BluetoothPage() {
                       if (device.connected) {
                         bash(`bluetoothctl disconnect ${device.address}`);
                       } else {
+                        bash(`bluetoothctl trust ${device.address}`);
                         bash(`bluetoothctl connect ${device.address}`);
                       }
                     }}
@@ -57,7 +59,7 @@ export default function BluetoothPage() {
                           label={`Battery: ${Math.floor(device.get_battery_percentage() * 100)}%`}
                           halign={Gtk.Align.END} // Align to the right
                           hexpand={true} // Allow the label to expand
-                          />
+                        />
                       )}
                     </box>
                   </button>

--- a/widgets/quicksettings/pages/BluetoothPage.tsx
+++ b/widgets/quicksettings/pages/BluetoothPage.tsx
@@ -7,7 +7,6 @@ import { bash } from "../../../utils";
 export default function BluetoothPage() {
   const bluetooth = AstalBluetooth.get_default();
   const btAdapter = bluetooth.adapter;
-  btAdapter.start_discovery();
 
   return (
     <box

--- a/widgets/quicksettings/pages/BluetoothPage.tsx
+++ b/widgets/quicksettings/pages/BluetoothPage.tsx
@@ -52,13 +52,13 @@ export default function BluetoothPage() {
                     }}
                   >
                     <box>
-                      <image iconName={device.iconName} />
+                      <image iconName={device.get_icon()} />
                       <label label={device.name} />
                       {device.connected && (
                         <label
                           label={`Battery: ${Math.floor(device.get_battery_percentage() * 100)}%`}
-                          halign={Gtk.Align.END} // Align to the right
-                          hexpand={true} // Allow the label to expand
+                          halign={Gtk.Align.END}
+                          hexpand={true}
                         />
                       )}
                     </box>

--- a/widgets/quicksettings/pages/BluetoothPage.tsx
+++ b/widgets/quicksettings/pages/BluetoothPage.tsx
@@ -52,11 +52,11 @@ export default function BluetoothPage() {
                     }}
                   >
                     <box>
-                      <image iconName={device.get_icon()} />
+                      <image iconName={device.icon} />
                       <label label={device.name} />
                       {device.connected && (
                         <label
-                          label={`Battery: ${Math.floor(device.get_battery_percentage() * 100)}%`}
+                          label={`Battery: ${Math.floor(device.batteryPercentage * 100)}%`}
                           halign={Gtk.Align.END}
                           hexpand={true}
                         />

--- a/widgets/quicksettings/pages/BluetoothPage.tsx
+++ b/widgets/quicksettings/pages/BluetoothPage.tsx
@@ -1,0 +1,71 @@
+import AstalBluetooth from "gi://AstalBluetooth";
+import { qsPage } from "../QSWindow";
+import { Gtk } from "astal/gtk4";
+import { bind } from "astal";
+import { bash } from "../../../utils";
+
+export default function BluetoothPage() {
+  const bluetooth = AstalBluetooth.get_default();
+  const btAdapter = bluetooth.adapter;
+
+  return (
+    <box
+      name={"bluetooth"}
+      cssClasses={["bluetooth-page", "qs-page"]}
+      vertical
+      spacing={6}
+    >
+      <box hexpand={false} cssClasses={["header"]} spacing={6}>
+        <button
+          onClicked={() => {
+            qsPage.set("main");
+          }}
+          iconName={"go-previous-symbolic"}
+        />
+        <label label={"Bluetooth"} hexpand xalign={0} />
+      </box>
+      <Gtk.Separator />
+      <Gtk.ScrolledWindow vexpand>
+        <box vertical spacing={6}>
+          {bind(bluetooth, "devices").as((devices) => {
+            const seenNames = new Set();
+            return devices
+              .filter((device) => device.name && !seenNames.has(device.name))
+              .map((device) => {
+                seenNames.add(device.name);
+
+                return (
+                  <button
+                    cssClasses={bind(device, "connected").as((connected) => {
+                      const classes = ["button"];
+                      connected && classes.push("active");
+                      return classes;
+                    })}
+                    onClicked={() => {
+                      if (device.connected) {
+                        bash(`bluetoothctl disconnect ${device.address}`);
+                      } else {
+                        bash(`bluetoothctl connect ${device.address}`);
+                      }
+                    }}
+                  >
+                    <box>
+                      <image iconName={device.iconName} />
+                      <label label={device.name} />
+                      {device.connected && (
+                        <label
+                          label={`Battery: ${Math.floor(device.get_battery_percentage() * 100)}%`}
+                          halign={Gtk.Align.END} // Align to the right
+                          hexpand={true} // Allow the label to expand
+                          />
+                      )}
+                    </box>
+                  </button>
+                );
+              });
+          })}
+        </box>
+      </Gtk.ScrolledWindow>
+    </box>
+  );
+}


### PR DESCRIPTION
I know you don't accept feature requests but I saw you wanting to add a bluetooth page so i decided to take a shot at it and here is my take.

Adds bluetooth page
Trust device that's being connected to.

Bugs:
Multiple of the same device name displays on page